### PR TITLE
Change CI workflow to only run once in a PR

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,5 +1,11 @@
 name: Linter
-on: [push, pull_request]
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
 jobs:
   ruff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently, the CI jobs run twice because of `push` and `pull_request`.
This PR changes this behavior so in a PR it only runs once.