### PR TITLE
Add dark mode styles for file selection and upload components

### DIFF
--- a/static/css/dark-mode.css
+++ b/static/css/dark-mode.css
@@ -877,4 +877,31 @@ body.dark-mode {
 .dark-mode div.toast.error {
     background-color: var(--secondary-bg);
     color: var(--langchain-white);
+}
+
+.dark-mode .file-selection-modal {
+    background-color: var(--primary-bg);
+    border: 1px solid var(--border-color);
+}
+
+.dark-mode .file-selection-content {
+    background-color: var(--secondary-bg);
+    color: var(--text-color);
+}
+
+.dark-mode .file-upload-btn {
+    background-color: var(--secondary-bg);
+    color: var(--text-color);
+    border: 1px solid var(--border-color);
+}
+
+.dark-mode input[type="file"] {
+    background-color: var(--secondary-bg);
+    color: var(--text-color);
+    border: 1px solid var(--border-color);
+}
+
+.dark-mode .file-upload-area {
+    border: 2px dashed var(--border-color);
+    background-color: var(--secondary-bg);
 } 


### PR DESCRIPTION
The file upload popup is now changed to dark mode, but the block is still in the same style as before.

Before
<img width="1440" alt="Skärmavbild 2025-04-10 kl  21 51 49" src="https://github.com/user-attachments/assets/42dbca1a-f249-4bcf-bcea-f9a833e1e8b5" />

After
<img width="1440" alt="Skarmavbild_2025-04-10_kl _21 58 30" src="https://github.com/user-attachments/assets/a0791e6e-0f30-4d74-b436-00f753feae70" />

Block
<img width="260" alt="Skärmavbild 2025-04-10 kl  22 08 28" src="https://github.com/user-attachments/assets/6cc77614-96e2-495a-a3cb-c8cb2daddbfa" />
