### PR TITLE
Add Werkzeug as dep in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ faiss-cpu
 numpy
 requests
 langchain
-langchain-community 
+langchain-community
+Werkzeug==2.2.2


### PR DESCRIPTION
The following error happens if I tried to start the server via `python server.py`:
`ImportError: cannot import name 'url_quote' from 'werkzeug.urls'`

As described on [Stackoverflow](https://stackoverflow.com/questions/77213053/why-did-flask-start-failing-with-importerror-cannot-import-name-url-quote-fr) `Flask` in version ~ 2.2.2 is not compatible with the resolved version of `Werkzeug` in version 3.0.0.

Pointing to the specific version `Werkzeug==2.2.2` resolves this issue for me.