### PR TITLE
Fix Design for blocks in darmkode

### DIFF
--- a/static/css/custom-blocks.css
+++ b/static/css/custom-blocks.css
@@ -71,7 +71,6 @@
     height: 30%;
     border-top-left-radius: 7px;
     border-top-right-radius: 7px;
-    border-bottom: 1px solid #eee;
     background-color: var(--langchain-primary);
     padding: 0;
     height: 100%;
@@ -87,7 +86,6 @@
     font-size: 13px;
     color: white;
     background-color: transparent;
-    border-bottom: 1px solid #eee;
     padding: 8px;
     display: flex;
     align-items: center;

--- a/static/css/dark-mode.css
+++ b/static/css/dark-mode.css
@@ -668,7 +668,7 @@ body.dark-mode {
 
 .dark-mode .custom-block .method-selectors {
     background-color: var(--secondary-bg);
-    border: 1px solid var(--border-color);
+    /* border: 1px solid var(--border-color); */
 }
 
 .dark-mode .custom-block .method-select {
@@ -709,9 +709,14 @@ body.dark-mode {
     color: var(--text-color);
 }
 
+.dark-mode .custom-block .block-content {
+    background-color: var(--secondary-bg);
+    /* border: 1px solid var(--border-color); */
+}
+
 .dark-mode .block-template[data-block-type="custom"] {
     background-color: var(--secondary-bg);
-    border: 1px solid var(--border-color);
+    /* border: 1px solid var(--border-color); */
 }
 
 .dark-mode .block-template[data-block-type="custom"] .block-header {


### PR DESCRIPTION
Updated design for blocks in design mode.

No longer has white background on canvas.
Border around selector removed to be a bit more minimalistic
White bottom border on block-template removed.

Close #58 

![image](https://github.com/user-attachments/assets/f15f25b0-d077-4833-b07a-3f0254e380a4)


