### PR TITLE
Remove dark mode support from block_content.css

### DIFF
--- a/static/css/block_content.css
+++ b/static/css/block_content.css
@@ -132,25 +132,6 @@
     color: var(--tag-color);
 }
 
-/* Dark mode support */
-@media (prefers-color-scheme: dark) {
-    .parameter-table {
-        background: var(--dark-block-bg-color, #2d2d2d);
-    }
-
-    .parameter-table-header {
-        background: var(--dark-header-bg-color, #363636);
-    }
-
-    .parameter-row:hover {
-        background-color: var(--dark-hover-bg-color, #383838);
-    }
-
-    .default-value {
-        background: var(--dark-tag-bg-color, #404040);
-    }
-}
-
 /* Responsive design */
 @media (max-width: 768px) {
     .parameter-table-header,


### PR DESCRIPTION
<img width="1440" alt="Skärmavbild 2025-05-05 kl  18 36 58" src="https://github.com/user-attachments/assets/6f7c437e-1e50-409e-972d-9e5a95b51a95" />
<img width="1440" alt="Skärmavbild 2025-05-05 kl  19 01 02" src="https://github.com/user-attachments/assets/43506614-b7aa-48a0-8d1d-bd47acbe5852" />
