### PR TITLE
Update README.md removing table of contents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,25 +4,6 @@
 
 RAGgie is a powerful, user-friendly web application for creating, testing, and exporting Retrieval Augmented Generation (RAG) pipelines. It provides a visual block-based interface where users can connect various LLM components to build custom RAG workflows without writing code.
 
-## Table of Contents
-
-- [Overview](#overview)
-- [Features](#features)
-- [Architecture](#architecture)
-- [Installation](#installation)
-- [Getting Started](#getting-started)
-- [Usage Guide](#usage-guide)
-- [Custom Block Creation](#custom-block-creation)
-- [Templates](#templates)
-- [Exporting Pipelines](#exporting-pipelines)
-- [Customization](#customization)
-- [Security and Authentication](#security-and-authentication)
-- [Deployment](#deployment)
-- [Docker](#docker)
-- [Troubleshooting](#troubleshooting)
-- [Contributing](#contributing)
-- [License](#license)
-
 ## Overview
 
 RAGgie simplifies the process of building Retrieval Augmented Generation (RAG) pipelines by providing a visual interface where users can:


### PR DESCRIPTION
This PR removes the table of contents section from the `README.md`.

GitHub has a built-in table of contents list (see screenshot). 
Having a hard-coded table of contents section requires constant updates if something in the structure changes.

![image](https://github.com/user-attachments/assets/fd2534f6-0a81-43b6-afcf-009063a9868f)